### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@
 > - 死亡信息 *(ps:该信息，客户端需增加材质包)* :
 >   - zh-cn: %1$s被%2$s的雪球打倒了，真是太菜了！
 >   - en-us: %1$s was knocked down by %2$s's snowball. What a loser!
+
+## 2.修改末影珍珠发射冷却时长
+> **效果:**
+> 当添加该标签后，会根据itemStack中custom_data组件中CoolDownTick中数值给予对应的发射冷却时长
+> - 为末影珍珠增加自定义物品堆叠组件并修改发射冷却时长   
+> **CoolDownTick&CoolDownSecond**标签  
+> 类型：*int*
+> - 获取指令:  
+> */give @s minecraft:ender_pearl[minecraft:custom_data={CoolDownTick:20}]*  
+> */give @s minecraft:ender_pearl[minecraft:custom_data={CoolDownSecond:1}]*
+> - **注意事项**   
+> *1.CoolDownTick所对应的数值为游戏刻,**1s=20GameTick**(即为gt或t),切勿填入秒数,否则会大幅减小冷却时长*
+> *2.CoolDownSecond仅支持对应整数数值,若要精确控制请使用CoolDownTick标签*  
+> *3.CoolDownTick和CoolDownSecond不可同时使用,若同时使用会导致末影珍珠实际冷却时长为CoolDownTick对应的数值*

--- a/src/main/java/lazyalienserver/lasmingamemod/mixins/AddedDamageTagToNBT/DataComponentTypesMixin.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/mixins/AddedDamageTagToNBT/DataComponentTypesMixin.java
@@ -1,12 +1,12 @@
 package lazyalienserver.lasmingamemod.mixins.AddedDamageTagToNBT;
 
-import lazyalienserver.lasmingamemod.utils.NBTList;
+import lazyalienserver.lasmingamemod.utils.ItemStackComponentList;
 import net.minecraft.component.DataComponentTypes;
 import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(DataComponentTypes.class)
 public class DataComponentTypesMixin {
     static{
-        NBTList.init();
+        ItemStackComponentList.init();
     }
 }

--- a/src/main/java/lazyalienserver/lasmingamemod/mixins/AddedDamageTagToNBT/SnowballItemMixin.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/mixins/AddedDamageTagToNBT/SnowballItemMixin.java
@@ -1,6 +1,6 @@
 package lazyalienserver.lasmingamemod.mixins.AddedDamageTagToNBT;
 
-import lazyalienserver.lasmingamemod.utils.NBTHelper;
+import lazyalienserver.lasmingamemod.utils.ItemStackComponentHelper;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,9 +21,9 @@ public class SnowballItemMixin {
 
     @Inject(at= @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"),method = "use",locals = LocalCapture.CAPTURE_FAILHARD)
     private void use(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir, ItemStack itemStack, SnowballEntity snowballEntity){
-        NbtComponent nbtComponent = NBTHelper.getNbt(itemStack, DataComponentTypes.CUSTOM_DATA);
+        NbtComponent nbtComponent = ItemStackComponentHelper.getNbt(itemStack, DataComponentTypes.CUSTOM_DATA);
         if (nbtComponent==null||!nbtComponent.contains("hitDamage")) return;
-        Float hitDamage = NBTHelper.getNbt(itemStack, DataComponentTypes.CUSTOM_DATA).copyNbt().getFloat("hitDamage");
-        snowballEntity.lasMinGameMod$setHitDamage(hitDamage==null?0.0f:hitDamage);
+        float hitDamage = nbtComponent.copyNbt().getFloat("hitDamage");
+        snowballEntity.lasMinGameMod$setHitDamage(hitDamage);
     }
 }

--- a/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
@@ -18,15 +18,17 @@ import org.spongepowered.asm.mixin.Overwrite;
 
 @Mixin(EnderPearlItem.class)
 public class EnderPearlItemMixin {
+
+    private final EnderPearlItem enderPearlItem = (EnderPearlItem) (Object)this;//定义this
+
     //用Overwrite写的矢山,不过能跑,不动了(
     /**
-     * @author
-     * @reason
+     * @author DIOJOIO
+     * @reason 修改冷却时间
      */
     @Overwrite
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         int CoolDownTick=20;//默认20tick
-        EnderPearlItem enderPearlItem = (EnderPearlItem) (Object)this;//定义this
         ItemStack itemStack = user.getStackInHand(hand);
         NbtComponent nbtComponent = ItemStackComponentHelper.getNbt(itemStack, DataComponentTypes.CUSTOM_DATA);//获得持有物品的custom_data内容
         if (nbtComponent!=null&&nbtComponent.contains("CoolDownTick")){//判断是否不为null和是由有CoolDownTick标签,这俩别互换位置,危险

--- a/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
@@ -1,5 +1,8 @@
 package lazyalienserver.lasmingamemod.mixins.ChangeEnderPearlCD;
 
+import lazyalienserver.lasmingamemod.utils.ItemStackComponentHelper;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
 import net.minecraft.item.EnderPearlItem;
@@ -16,17 +19,23 @@ import org.spongepowered.asm.mixin.Overwrite;
 @Mixin(EnderPearlItem.class)
 public class EnderPearlItemMixin {
     //用Overwrite写的矢山,不过能跑,不动了(
-    //注释不写了,一眼看懂(
     /**
      * @author
      * @reason
      */
     @Overwrite
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        EnderPearlItem enderPearlItem = (EnderPearlItem) (Object)this;
+        int CoolDownTick=20;//默认20tick
+        EnderPearlItem enderPearlItem = (EnderPearlItem) (Object)this;//定义this
         ItemStack itemStack = user.getStackInHand(hand);
-        world.playSound((PlayerEntity)null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_ENDER_PEARL_THROW, SoundCategory.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
-        user.getItemCooldownManager().set(enderPearlItem, 200);
+        NbtComponent nbtComponent = ItemStackComponentHelper.getNbt(itemStack, DataComponentTypes.CUSTOM_DATA);//获得持有物品的custom_data内容
+        if (nbtComponent!=null&&nbtComponent.contains("CoolDownTick")){//判断是否不为null和是由有CoolDownTick标签,这俩别互换位置,危险
+            CoolDownTick=nbtComponent.copyNbt().getInt("CoolDownTick");
+        } else if (nbtComponent!=null&&nbtComponent.contains("CoolDownSecond")) {//判断是否不为null和是由有CoolDownSecond标签,这俩别互换位置,危险
+            CoolDownTick=nbtComponent.copyNbt().getInt("CoolDownSecond")*20;
+        }
+        world.playSound(null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_ENDER_PEARL_THROW, SoundCategory.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
+        user.getItemCooldownManager().set(enderPearlItem, CoolDownTick);
         if (!world.isClient) {
             EnderPearlEntity enderPearlEntity = new EnderPearlEntity(world, user);
             enderPearlEntity.setItem(itemStack);

--- a/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/mixins/ChangeEnderPearlCD/EnderPearlItemMixin.java
@@ -1,0 +1,41 @@
+package lazyalienserver.lasmingamemod.mixins.ChangeEnderPearlCD;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
+import net.minecraft.item.EnderPearlItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(EnderPearlItem.class)
+public class EnderPearlItemMixin {
+    //用Overwrite写的矢山,不过能跑,不动了(
+    //注释不写了,一眼看懂(
+    /**
+     * @author
+     * @reason
+     */
+    @Overwrite
+    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
+        EnderPearlItem enderPearlItem = (EnderPearlItem) (Object)this;
+        ItemStack itemStack = user.getStackInHand(hand);
+        world.playSound((PlayerEntity)null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_ENDER_PEARL_THROW, SoundCategory.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
+        user.getItemCooldownManager().set(enderPearlItem, 200);
+        if (!world.isClient) {
+            EnderPearlEntity enderPearlEntity = new EnderPearlEntity(world, user);
+            enderPearlEntity.setItem(itemStack);
+            enderPearlEntity.setVelocity(user, user.getPitch(), user.getYaw(), 0.0F, 1.5F, 1.0F);
+            world.spawnEntity(enderPearlEntity);
+        }
+
+        user.incrementStat(Stats.USED.getOrCreateStat(enderPearlItem));
+        itemStack.decrementUnlessCreative(1, user);
+        return TypedActionResult.success(itemStack, world.isClient());
+    }
+}

--- a/src/main/java/lazyalienserver/lasmingamemod/utils/ItemStackComponentHelper.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/utils/ItemStackComponentHelper.java
@@ -9,7 +9,7 @@ import net.minecraft.util.Identifier;
 
 import java.util.function.UnaryOperator;
 
-public class NBTHelper {
+public class ItemStackComponentHelper {
     public static boolean hasNbt(ItemStack itemStack, String keyName, ComponentType<?> type) {
         return !itemStack.isEmpty() && itemStack.getComponents() != null && itemStack.getComponents().contains(type);
     }

--- a/src/main/java/lazyalienserver/lasmingamemod/utils/ItemStackComponentList.java
+++ b/src/main/java/lazyalienserver/lasmingamemod/utils/ItemStackComponentList.java
@@ -1,10 +1,6 @@
 package lazyalienserver.lasmingamemod.utils;
 
-import com.mojang.serialization.Codec;
-import net.minecraft.component.ComponentType;
-import net.minecraft.network.codec.PacketCodecs;
-
-public class NBTList {
+public class ItemStackComponentList {
     //public static final ComponentType<Float> HIT_DAMAGE=NBTHelper.register("hit_damage",builder -> builder.codec(Codec.FLOAT).packetCodec(PacketCodecs.FLOAT));
     public static void init(){}
 }

--- a/src/main/resources/lasmingamemod.mixins.json
+++ b/src/main/resources/lasmingamemod.mixins.json
@@ -13,6 +13,7 @@
     "AddedDamageTagToNBT.DataComponentTypesMixin",
     "AddedDamageTagToNBT.SnowballEntityMixin",
     "AddedDamageTagToNBT.SnowballItemMixin",
-    "AddedDamageTagToNBT.ThrownItemEntityMixin"
+    "AddedDamageTagToNBT.ThrownItemEntityMixin",
+    "ChangeEnderPearlCD.EnderPearlItemMixin"
   ]
 }


### PR DESCRIPTION
## 2.修改末影珍珠发射冷却时长
> **效果:**
> 当添加该标签后，会根据itemStack中custom_data组件中CoolDownTick中数值给予对应的发射冷却时长
> - 为末影珍珠增加自定义物品堆叠组件并修改发射冷却时长   
> **CoolDownTick&CoolDownSecond**标签  
> 类型：*int*
> - 获取指令:  
> */give @s minecraft:ender_pearl[minecraft:custom_data={CoolDownTick:20}]*  
> */give @s minecraft:ender_pearl[minecraft:custom_data={CoolDownSecond:1}]*
> - **注意事项**   
> *1.CoolDownTick所对应的数值为游戏刻,**1s=20GameTick**(即为gt或t),切勿填入秒数,否则会大幅减小冷却时长*
> *2.CoolDownSecond仅支持对应整数数值,若要精确控制请使用CoolDownTick标签*  
> *3.CoolDownTick和CoolDownSecond不可同时使用,若同时使用会导致末影珍珠实际冷却时长为CoolDownTick对应的数值*